### PR TITLE
Fix Hex Calculation

### DIFF
--- a/autoload/colocolo.vim
+++ b/autoload/colocolo.vim
@@ -13,7 +13,7 @@ function! s:get_colorschemes() abort
 endfunction
 
 function! s:get_random_osyo(n) abort
-  return sha256(reltimestr(reltime()))[:7] % a:n
+  return ('0x'.sha256(reltimestr(reltime()))[:7]) % a:n
 endfunction
 
 function! s:choice(lst) abort


### PR DESCRIPTION
Hi, I enjoyed your funny plugin.
Then I found that my default color scheme often appeared.
I guess the cause is the hexadecimal number: it is recognized as zero sometimes.
Please check it!
